### PR TITLE
DRAFT: Stub out mocked backend Vue plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2357,6 +2357,53 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "axios-mock-adapter": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.18.1.tgz",
+      "integrity": "sha512-kFBZsG1Ma5yxjRGHq5KuuL55mPb7WzFULhypquEhzPg8SH5CXICb+qwC2CCA5u+GQVpiqGPwKSRkd3mBCs6gdw==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "is-buffer": "^2.0.3"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
+      }
+    },
     "babel-eslint": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
@@ -5739,8 +5786,7 @@
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-      "dev": true
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-diff": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
+    "axios-mock-adapter": "^1.18.1",
     "core-js": "^3.6.4",
     "resonance": "git+ssh://git@github.com/voxmedia/resonance.git#v0.19.0",
     "vue": "^2.6.11",

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,9 @@ import router from "./router";
 import "./plugins/resonance";
 import "./assets/css/shared_styles.css";
 import vuetify from "./plugins/vuetify";
+import myAxios from "./plugins/axios";
+
+Vue.use(myAxios);
 
 Vue.config.productionTip = false;
 

--- a/src/plugins/axios.js
+++ b/src/plugins/axios.js
@@ -1,0 +1,32 @@
+import * as axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+const MockableAxios = {};
+
+// const BASE_URL = "http://localhost:5000";
+const BASE_URL = "https://themui-backend.herokuapp.com";
+
+MockableAxios.install = function(Vue) {
+  axios.defaults.baseURL = BASE_URL;
+
+  let mock = new MockAdapter(axios);
+
+  mock.onPost("/upload").reply(function() {
+    console.log("Mocked upload");
+    return [
+      200,
+      {
+        filename: "a filename"
+      }
+    ];
+  });
+
+  mock.onPost(/\/upload\/\.+/).reply(function(config) {
+    console.log("Mocked upload with filename", config);
+    return [200, {}];
+  });
+
+  Vue.prototype.$axios = axios;
+};
+
+export default MockableAxios;

--- a/src/views/Fonts.vue
+++ b/src/views/Fonts.vue
@@ -245,10 +245,8 @@
 </template>
 
 <script>
-import * as axios from "axios";
 
-// const BASE_URL = "http://localhost:5000";
-const BASE_URL = "https://themui-backend.herokuapp.com";
+
 const STATUS_INITIAL = 0,
   STATUS_SAVING = 1,
   STATUS_SUCCESS = 2,
@@ -315,10 +313,10 @@ export default {
       this.save(formData);
     },
     upload(formData) {
-      const url = `${BASE_URL}/upload`;
+      const url = `/upload`;
       console.log(`url: ${url}`);
       return (
-        axios
+        this.$axios
           .post(url, formData)
           // get data
           .then(x => {
@@ -330,7 +328,7 @@ export default {
           .then(x => {
             console.log("2nd then");
             return Object.assign({}, x.file, {
-              url: `${BASE_URL}/uploads/${x.filename}`
+              url: `/uploads/${x.filename}`
             });
             // x.map(img => {
             //   console.log('===== img');


### PR DESCRIPTION
Comment from https://voxmedia.slack.com/archives/G010HTQ439U/p1585335750017100

This takes advantage of [axios-mock-adapter](https://github.com/ctimmerm/axios-mock-adapter#readme), a library designed to fake responses from http requests sent from axios. This allows us to define specific responses that normally would come from an HTTP endpoint.

I extracted the imported axios library from directly in the Fonts vue directive and created a plugin which adds `$axios` to the global Vue namespace. This copy of axios is configured to return set values on `/upload` and `/upload/[id]` calls. 

I also took advantage of axios's ability to set a default baseurl so that we can use relative links with API calls, rather than munging them together across the codebase.

If this approach is adopted, I would love to eventually see an environment variable that toggles using Tower or mocked responses, which would be enabled for local development and automated interface testing, and disabled during integration testing and production. I'm also not a fan of the plugin name that I created, any guidance on a better naming convention is welcome. 😄 